### PR TITLE
fix: use pre-release number for comparison

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -119,7 +119,7 @@ exports.compare = function (a, b, options = {}) {
             return an ? aFirst : bFirst;
         }
 
-        return (a < b ? aFirst : bFirst);
+        return (ai < bi ? aFirst : bFirst);
     }
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -232,6 +232,12 @@ describe('Version', () => {
         expect(version.build).to.equal([]);
     });
 
+    it('converts to string', () => {
+
+        const version = Somever.version({ prerelease: [1], build: ['abc'] });
+        expect(`${version}`).to.equal('x.x.x-1+abc');
+    });
+
     describe('_parse()', () => {
 
         it('throws on invalid version string', () => {
@@ -316,6 +322,10 @@ describe('compare()', () => {
         expect(Somever.compare('1.1.2-bis.z.1.3', '1.1.2-bis.z.1.4')).to.equal(-1);
         expect(Somever.compare('1.1.2-bis.1.3', '1.1.2-bis.1.z')).to.equal(-1);
         expect(Somever.compare('1.1.2-bis.1.z', '1.1.2-bis.1.3')).to.equal(1);
+        expect(Somever.compare('1.1.2-bis.z.1.1', '1.1.2-bis.z.1.10')).to.equal(-1);
+        expect(Somever.compare('1.1.2-bis.z.1.10', '1.1.2-bis.z.1.1')).to.equal(1);
+        expect(Somever.compare('1.1.2-bis.z.1.3', '1.1.2-bis.z.1.10')).to.equal(-1);
+        expect(Somever.compare('1.1.2-bis.z.1.10', '1.1.2-bis.z.1.3')).to.equal(1);
     });
 });
 


### PR DESCRIPTION
`a` / `b` are parsed version objects. When they are compared, they are coerced to primitives (which results in `toString()` getting called). This does have problems, because `'3' > '10'` - we need to compare the actual numeric component of the parsed pre-release number.

Spec: https://semver.org/#spec-item-11 

> Identifiers consisting of only digits are compared numerically.
