### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches:
+      - v4
       - master
   pull_request:
   workflow_dispatch:
@@ -10,3 +11,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2018-2020, Sideway Inc, and project contributors  
+Copyright (c) 2018-2022, Project contributors
+Copyright (c) 2018-2020, Sideway Inc
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -149,8 +149,8 @@ internals.Version = class {
         this.major = version.major === undefined ? internals.any : version.major;
         this.minor = version.minor === undefined ? internals.any : version.minor;
         this.patch = version.patch === undefined ? internals.any : version.patch;
-        this.prerelease = version.prerelease || [];
-        this.build = version.build || [];
+        this.prerelease = version.prerelease ?? [];
+        this.build = version.build ?? [];
     }
 
     _parse(version, options) {

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     ]
   },
   "dependencies": {
-    "@hapi/bounce": "2.x.x",
-    "@hapi/hoek": "9.x.x"
+    "@hapi/bounce": "^3.0.0",
+    "@hapi/hoek": "^9.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "25.0.0-beta.1"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",


### PR DESCRIPTION
 - Test on node v14+ and adopt some new syntax.
 - Update to node v18-compatible versions of hoek, bounce, lab, and code.

If this looks good, this will go out as somever v4.