### PR TITLE
Support includePrerelease option to permit prereleases when matching ranges

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,10 +32,10 @@ exports.range = function (range) {
 };
 
 
-exports.match = function (version, range) {
+exports.match = function (version, range, options) {
 
     try {
-        return exports.range(range).match(version);
+        return exports.range(range).match(version, options);
     }
     catch (err) {
         Bounce.rethrow(err, 'system');
@@ -54,7 +54,7 @@ exports.compare = function (a, b, options = {}) {
 
     // Mark incompatible prereleases
 
-    if (options.range &&
+    if (options.range && !options.includePrerelease &&
         a.prerelease.length &&
         (a.major !== b.major || a.minor !== b.minor || a.patch !== b.patch || !b.prerelease.length)) {
 
@@ -80,14 +80,16 @@ exports.compare = function (a, b, options = {}) {
 
     // Compare prerelease
 
-    if (!a.prerelease.length &&
-        !b.prerelease.length) {
+    // With includePrerelease patch wildcard encompasses prereleases, otherwise prerelease < none
 
+    if (!a.prerelease.length && !b.prerelease.length) {
         return 0;
     }
-
-    if (!!a.prerelease.length !== !!b.prerelease.length) {
-        return (a.prerelease.length ? aFirst : bFirst);         // prerelease < none
+    else if (!b.prerelease.length) {
+        return options.includePrerelease && b.patch === internals.any ? 0 : aFirst;
+    }
+    else if (!a.prerelease.length) {
+        return options.includePrerelease && a.patch === internals.any ? 0 : bFirst;
     }
 
     for (let i = 0; ; ++i) {
@@ -330,10 +332,10 @@ internals.Range = class {
         this._rule('>=', version);
 
         if (version.minor === internals.any) {
-            this._rule('<', { major: version.major + 1, minor: 0, patch: 0 });
+            this._rule('<', { major: version.major + 1, minor: 0, patch: 0, prerelease: [0] });
         }
         else {
-            this._rule('<', { major: version.major, minor: version.minor + 1, patch: 0 });
+            this._rule('<', { major: version.major, minor: version.minor + 1, patch: 0, prerelease: [0] });
         }
 
         return this;
@@ -358,14 +360,14 @@ internals.Range = class {
             version.minor !== internals.any) {
 
             if (version.minor === 0) {
-                this._rule('<', { major: 0, minor: 0, patch: version.patch + 1 });
+                this._rule('<', { major: 0, minor: 0, patch: version.patch + 1, prerelease: [0] });
             }
             else {
-                this._rule('<', { major: 0, minor: version.minor + 1, patch: 0 });
+                this._rule('<', { major: 0, minor: version.minor + 1, patch: 0, prerelease: [0] });
             }
         }
         else {
-            this._rule('<', { major: version.major + 1, minor: 0, patch: 0 });
+            this._rule('<', { major: version.major + 1, minor: 0, patch: 0, prerelease: [0] });
         }
 
         return this;
@@ -451,12 +453,12 @@ internals.Range = class {
         }
     }
 
-    match(version) {
+    match(version, options = {}) {
 
         version = exports.version(version, this._settings);       // Always parse to validate
 
         if (this._anything) {
-            return !version.prerelease.length;
+            return !!options.includePrerelease || !version.prerelease.length;
         }
 
         for (const { rules } of this._or) {
@@ -468,7 +470,7 @@ internals.Range = class {
             let excludes = 0;
 
             for (const rule of rules) {
-                const compare = version.compare(rule.version, Object.assign(this._settings, { range: true }));
+                const compare = version.compare(rule.version, Object.assign(this._settings, options, { range: true }));
                 const exclude = Math.abs(compare) === 2;
 
                 if (rule.compare.includes(compare / (exclude ? 2 : 1))) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "25.0.0-beta.1"
+    "@hapi/lab": "^25.0.1"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",


### PR DESCRIPTION
This adds an option `includePrerelease` to permit prereleases when matching ranges, similar to the option of the same name in the semver module.  The new tests here parallel those from the semver module to ensure both implementations are in agreement.  Resolves #18 

Here's an example:
```js
Somever.match('1.0.1-rc1', '^1.0.0');                              // false
Somever.match('1.0.1-rc1', '^1.0.0', { includePrerelease: true }); // true
```